### PR TITLE
feat: Autoware切断時の表示を追加

### DIFF
--- a/src/signage/src/signage/autoware_interface.py
+++ b/src/signage/src/signage/autoware_interface.py
@@ -14,7 +14,6 @@ from autoware_adapi_v1_msgs.msg import (
 import signage.signage_utils as utils
 from tier4_debug_msgs.msg import Float64Stamped
 from tier4_external_api_msgs.msg import DoorStatus
-# from autoware_auto_system_msgs.msg import HazardStatusStamped
 
 @dataclass
 class AutowareInformation:

--- a/src/signage/src/signage/autoware_interface.py
+++ b/src/signage/src/signage/autoware_interface.py
@@ -9,11 +9,12 @@ from autoware_adapi_v1_msgs.msg import (
     OperationModeState,
     MotionState,
     LocalizationInitializationState,
+    VelocityFactorArray,
 )
 import signage.signage_utils as utils
 from tier4_debug_msgs.msg import Float64Stamped
 from tier4_external_api_msgs.msg import DoorStatus
-
+# from autoware_auto_system_msgs.msg import HazardStatusStamped
 
 @dataclass
 class AutowareInformation:
@@ -31,6 +32,7 @@ class AutowareInterface:
     def __init__(self, node):
         self._node = node
         self.information = AutowareInformation()
+        self.is_disconnected = False
 
         sub_qos = rclpy.qos.QoSProfile(
             history=rclpy.qos.QoSHistoryPolicy.KEEP_LAST,
@@ -81,6 +83,12 @@ class AutowareInterface:
             self.sub_localization_initialization_state_callback,
             api_qos,
         )
+        self._sub_velocity_factors = node.create_subscription(
+            VelocityFactorArray,
+            "/api/planning/velocity_factors",
+            self.sub_velocity_factors_callback,
+            sub_qos,
+        )
         self._autoware_connection_time = self._node.get_clock().now()
         self._node.create_timer(2, self.reset_timer)
 
@@ -88,6 +96,9 @@ class AutowareInterface:
         if utils.check_timeout(self._node.get_clock().now(), self._autoware_connection_time, 10):
             self.information = AutowareInformation()
             self._node.get_logger().error("Autoware disconnected", throttle_duration_sec=10)
+            self.is_disconnected = True
+        else:
+            self.is_disconnected = False
 
     def sub_operation_mode_callback(self, msg):
         try:
@@ -116,7 +127,6 @@ class AutowareInterface:
 
     def sub_path_distance_callback(self, msg):
         try:
-            self._autoware_connection_time = self._node.get_clock().now()
             self.information.goal_distance = msg.data
         except Exception as e:
             self._node.get_logger().error("Unable to get the goal distance, ERROR: " + str(e))
@@ -134,3 +144,9 @@ class AutowareInterface:
             self._node.get_logger().error(
                 "Unable to get the localization init state, ERROR: " + str(e)
             )
+
+    def sub_velocity_factors_callback(self, msg):
+        try:
+            self._autoware_connection_time = self._node.get_clock().now()
+        except Exception as e:
+            self._node.get_logger().error("Unable to get the velocity factors, ERROR: " + str(e))

--- a/src/signage/src/signage/route_handler.py
+++ b/src/signage/src/signage/route_handler.py
@@ -370,7 +370,9 @@ class RouteHandler:
             self._viewController.next_station_list = self._display_details.next_station_list
             self._viewController.display_phrase = self._display_phrase
 
-            if (
+            if self._autoware.is_disconnected:
+                view_mode = "emergency_stopped"
+            elif (
                 not self._autoware.information.autoware_control
                 and not self._parameter.ignore_manual_driving
             ):


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)

Autowareとの接続が切れたときに緊急停止表示にするようにしました
もともと残り距離のトピックで切断を判断する機能がありましたが経路が引かれていないとトピックが出力されないためvelocity factorsのAPIで判断するようにしました

<!-- Describe what this PR changes. -->

## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write release notes

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
