### PR TITLE
hotfix: 切断時の表示を専用の表示に変える

### DIFF
--- a/src/signage/resource/page/Disconnected.qml
+++ b/src/signage/resource/page/Disconnected.qml
@@ -14,11 +14,25 @@ Rectangle {
     }
 
     Text {
-        id: disconnectedText
-        color: "#ef642c"
-        text: qsTr("自動運転システムとの通信が遅延しています")
+        id: disconnectedText1
+        color: "#000000"
+        text: qsTr("通信不良が発生しています。")
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.verticalCenter
+        anchors.bottomMargin: 50*viewController.size_ratio
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        font.pointSize: 40*viewController.size_ratio
+        font.bold: true
+        elide: Text.ElideMiddle
+    }
+
+        Text {
+        id: disconnectedText2
+        color: "#000000"
+        text: qsTr("急な停車にご注意ください。")
+        anchors.top: disconnectedText1.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         font.pointSize: 40*viewController.size_ratio
@@ -28,13 +42,14 @@ Rectangle {
 
     Text {
         id: disconnectedEnText
-        color: "#ef642c"
+        color: "#000000"
         text: qsTr("Communication with the autonomous system is delayed.")
-        anchors.top: disconnectedText.bottom
+        anchors.top: disconnectedText2.bottom
+        anchors.topMargin: 20*viewController.size_ratio
         anchors.horizontalCenter: parent.horizontalCenter
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
-        font.pointSize: 40*viewController.size_ratio
+        font.pointSize: 30*viewController.size_ratio
         font.bold: true
         elide: Text.ElideMiddle
     }

--- a/src/signage/resource/page/Disconnected.qml
+++ b/src/signage/resource/page/Disconnected.qml
@@ -1,0 +1,41 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+
+import "Common"
+
+Rectangle {
+    id: disconnectedView
+    width: viewController.monitor_width
+    height: viewController.monitor_height
+    color: "#ffffff"
+
+    CurrentTime {
+        id: displayCurrentTime
+    }
+
+    Text {
+        id: disconnectedText
+        color: "#ef642c"
+        text: qsTr("自動運転システムとの通信が遅延しています")
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.bottom: parent.verticalCenter
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        font.pointSize: 40*viewController.size_ratio
+        font.bold: true
+        elide: Text.ElideMiddle
+    }
+
+    Text {
+        id: disconnectedEnText
+        color: "#ef642c"
+        text: qsTr("Communication with the autonomous system is delayed.")
+        anchors.top: disconnectedText.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        font.pointSize: 40*viewController.size_ratio
+        font.bold: true
+        elide: Text.ElideMiddle
+    }
+}

--- a/src/signage/resource/page/main.qml
+++ b/src/signage/resource/page/main.qml
@@ -19,6 +19,11 @@ Window {
         visible: viewController.view_mode === "emergency_stopped"
     }
 
+    Disconnected {
+        id: disconnected
+        visible: viewController.view_mode === "disconnected"
+    }
+
     SlowStopView {
         id: slowStopView
         visible: viewController.view_mode === "slow_stop"

--- a/src/signage/resource/page/main.qml
+++ b/src/signage/resource/page/main.qml
@@ -20,7 +20,7 @@ Window {
     }
 
     Disconnected {
-        id: disconnected
+        id: disconnectedView
         visible: viewController.view_mode === "disconnected"
     }
 

--- a/src/signage/src/signage/route_handler.py
+++ b/src/signage/src/signage/route_handler.py
@@ -454,7 +454,7 @@ class RouteHandler:
             self._viewController.display_phrase = self._display_phrase
 
             if self._autoware.is_disconnected:
-                view_mode = "emergency_stopped"
+                view_mode = "disconnected"
             elif (
                 not self._autoware.information.autoware_control
                 and not self._parameter.ignore_manual_driving


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)

切断を判定したとき緊急停止の表示をしていたがMRMと見分けがつかないので切断したことがわかる表示を作成した

<!-- Describe what this PR changes. -->

## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write release notes

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
