### PR TITLE
fix: do not launch external_signage from signage.launch.xml

### DIFF
--- a/src/signage/launch/signage.launch.xml
+++ b/src/signage/launch/signage.launch.xml
@@ -7,8 +7,6 @@
     <param from="$(var signage_param)"/>
     <param name="debug_mode" value="$(var debug_mode)" />
   </node>
-  <node pkg="external_signage" exec="external_signage"  output="screen" />
-
   <node pkg="signage_fms_client" exec="signage_fms_client"  output="screen" >
     <param from="$(var fms_client_param)"/>
   </node>


### PR DESCRIPTION
## Summary
- `signage.launch.xml` から `external_signage` ノードの起動を削除

## Test plan
- [x] `ros2 launch signage signage.launch.xml` を実行し、`external_signage` ノードが起動しないことを確認
- [x] `signage` / `signage_fms_client` ノードは従来通り起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)