### PR TITLE
refactor: externalize FMS host and port via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,25 @@ source {AUTOWARE_PATH}/install/setup.bash
 bash setup.sh
 ```
 
-IF you wont to use other FMS Domain, change environment variable.
+### Environment variables
+
+The following environment variables must be set before launching:
+
+- `FMS_URL`: FMS domain (e.g. set by your operations team)
+- `AUTOWARE_IP`: IP address of the Autoware PC running the FMS gateway
+- `AUTOWARE_PORT`: TCP port of the FMS gateway on the Autoware PC
+
+On production vehicles these are provisioned by the `x2_signage_env_setup` role
+in [`autoware_ecu_system_setup`](https://github.com/tier4/autoware_ecu_system_setup),
+which writes them into `autoware.env`. The signage service then sources
+`/opt/autoware/services/set-autoware-env/setup.sh` before launch.
+
+For local development, export them in your shell before running `start.sh`:
 
 ```bash
-export FMS_URL=fms.web.auto
+export FMS_URL=<your-fms-domain>
+export AUTOWARE_IP=<autoware-pc-ip>
+export AUTOWARE_PORT=<autoware-pc-port>
 ```
 
 ## start

--- a/src/signage_fms_client/src/signage_fms_client/signage_fms_client.py
+++ b/src/signage_fms_client/src/signage_fms_client/signage_fms_client.py
@@ -18,11 +18,12 @@ class FMSClient(Node):
         self._fms_payload = {
             "method": "get",
             "url": "https://"
-            + os.getenv("FMS_URL", "fms.web.auto")
+            + os.getenv("FMS_URL", "")
             + "/v1/projects/{project_id}/environments/{environment_id}/vehicles/{vehicle_id}/active_schedule",
             "body": {},
         }
         self.AUTOWARE_IP = os.getenv("AUTOWARE_IP", "localhost")
+        self.AUTOWARE_PORT = os.getenv("AUTOWARE_PORT", "")
         self.schedule_pub_ = node.create_publisher(String, "/signage/active_schedule", 10)
         self.timer = node.create_timer(self._post_request_time + 0.5, self.pub_schedule)
 
@@ -30,7 +31,7 @@ class FMSClient(Node):
         try:
             msg = String()
             respond = requests.post(
-                "http://{}:4711/v1/services/order".format(self.AUTOWARE_IP),
+                "http://{}:{}/v1/services/order".format(self.AUTOWARE_IP, self.AUTOWARE_PORT),
                 json=self._fms_payload,
                 timeout=self._post_request_time,
             )


### PR DESCRIPTION
## Summary

- Remove hardcoded FMS domain and gateway port from `signage_fms_client.py` so internal infrastructure details are no longer baked into the public repository.
- Read `FMS_URL`, `AUTOWARE_IP`, and `AUTOWARE_PORT` from environment variables instead.
- Update README to document the new env-var-based configuration and reference the `x2_signage_env_setup` Ansible role that provisions them into `autoware.env`.

Companion change in `autoware_ecu_system_setup` adds the new `autoware_pc_port` variable to `x2_signage_env_setup` and exports `AUTOWARE_PORT` to `autoware.env`.

## Test plan

- [x] Local PC: launched signage with `FMS_URL`, `AUTOWARE_IP`, `AUTOWARE_PORT` exported and confirmed FMS communication works.
- [x] Production vehicle: verify after the companion ansible role change is deployed.