### PR TITLE
ci: update GitHub Actions runner from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/sync-branch.yaml
+++ b/.github/workflows/sync-branch.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sync-tier4-upstream:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
## Summary
- Update GitHub Actions runner from `ubuntu-22.04` to `ubuntu-24.04`

## Notes
- `ubuntu-22.04-m` and `ubuntu-22.04-arm` are intentionally unchanged

## Test plan
- [ ] CI workflows pass on this PR
