### PR TITLE
fix: package.xmlからpython-pulsectl-pip依存を削除 (beta/v4.4.0.1)

### DIFF
--- a/src/external_signage/package.xml
+++ b/src/external_signage/package.xml
@@ -11,7 +11,6 @@
   <exec_depend>signage_version</exec_depend>
 
   <depend>diagnostic_updater</depend>
-  <depend>python-pulsectl-pip</depend>
   <depend>rclpy</depend>
   <depend>std_srvs</depend>
   <depend>tier4_api_msgs</depend>

--- a/src/signage/package.xml
+++ b/src/signage/package.xml
@@ -13,7 +13,6 @@
   <depend>command_view_manager_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>external_signage</depend>
-  <depend>python-pulsectl-pip</depend>
   <depend>rclpy</depend>
   <depend>signage_fms_client</depend>
   <depend>std_srvs</depend>


### PR DESCRIPTION
## 概要
`python-pulsectl-pip` の rosdep key が削除されたため、`rosdep install` での依存解決が失敗するようになりました。`pulsectl` のインストールは `autoware_ecu_system_setup` の `x2_signage_env_setup` の pip install に移管するため、package.xml からの依存宣言を削除します。

## 変更内容
- `src/signage/package.xml` から `<depend>python-pulsectl-pip</depend>` を削除
- `src/external_signage/package.xml` から `<depend>python-pulsectl-pip</depend>` を削除

## 注意点
- `announce_controller.py` の `from pulsectl import Pulse` はそのままです（実行時は pip でインストールされた pulsectl を使用）。
- 依存が package.xml から消えたため、`x2_signage_env_setup` を通していない環境（ローカルの `rosdep install`・CI 等）では `pulsectl` が入らず `ImportError` になります。pulsectl を使う全経路で pip install がカバーされているか確認が必要です。
- セットアップ側 (`autoware_ecu_system_setup` への pulsectl 追加) は別リポジトリで別途対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)