### PR TITLE
chore: pulsectl の rosdep 依存を package.xml から削除 (Ansible 導入へ移行)

### DIFF
--- a/src/external_signage/package.xml
+++ b/src/external_signage/package.xml
@@ -12,7 +12,6 @@
 
   <depend>autoware_auto_system_msgs</depend>
   <depend>diagnostic_updater</depend>
-  <depend>python-pulsectl-pip</depend>
   <depend>rclpy</depend>
   <depend>std_srvs</depend>
   <depend>tier4_api_msgs</depend>

--- a/src/signage/package.xml
+++ b/src/signage/package.xml
@@ -13,7 +13,6 @@
   <depend>autoware_auto_system_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>external_signage</depend>
-  <depend>python-pulsectl-pip</depend>
   <depend>rclpy</depend>
   <depend>signage_fms_client</depend>
   <depend>std_srvs</depend>


### PR DESCRIPTION
## 概要

`python-pulsectl-pip` の導入方法を **rosdep から Ansible での pip インストールに移行**するため、`package.xml` の rosdep 依存宣言を削除します。

## 変更内容

以下2パッケージの `package.xml` から `<depend>python-pulsectl-pip</depend>` を削除:

- `src/signage/package.xml`
- `src/external_signage/package.xml`

## 補足

- pulsectl 自体は `signage/announce_controller.py` (`from pulsectl import Pulse`) で引き続き使用します。導入経路を rosdep → Ansible に切り替えるのみで、実行時依存は変わりません。
- **Ansible 側での pulsectl インストール設定の追加は別リポジトリ (プロビジョニング) で対応**が必要です。本 PR マージ前に Ansible 側の導入が完了していることを確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)